### PR TITLE
Feature makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ $(QUARTO_EXT_DIR)/$(FILTER_FILE): $(FILTER_FILE) $(QUARTO_EXT_DIR)
 release: quarto-extension
 	git commit -am "Release $(FILTER_NAME) $(VERSION)"
 	git tag v$(VERSION) -m "$(FILTER_NAME) $(VERSION)"
+	@echo 'Do not forget to push the tag back to github with `git push --tags`'
 
 #
 # Set up (normally used only once)


### PR DESCRIPTION
I propose to add a default target which list available targets so that first call of `make` is safe.
I also add a warning in release target to remind to push the tags back to github.